### PR TITLE
Append only state

### DIFF
--- a/node/migrations/V1588079742__create_asset_states.sql
+++ b/node/migrations/V1588079742__create_asset_states.sql
@@ -10,9 +10,10 @@ CREATE TABLE asset_states (
                        expiry_date TIMESTAMPTZ NULL,
                        superseded_by uuid NULL references asset_states(id),
                        initial_permission_bitflag BIGINT NOT NULL DEFAULT 0,
-                       additional_data_json JSONB NOT NULL DEFAULT '{}',
+                       initial_data_json JSONB NOT NULL DEFAULT '{}',
                        asset_id char(64) NOT NULL UNIQUE,
                        digital_asset_id UUID references digital_assets(id),
+                       append_only_after TIMESTAMPTZ NOT NULL DEFAULT now(),
                        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/node/migrations/V1588079742__create_asset_states.sql
+++ b/node/migrations/V1588079742__create_asset_states.sql
@@ -13,7 +13,6 @@ CREATE TABLE asset_states (
                        initial_data_json JSONB NOT NULL DEFAULT '{}',
                        asset_id char(64) NOT NULL UNIQUE,
                        digital_asset_id UUID references digital_assets(id),
-                       append_only_after TIMESTAMPTZ NOT NULL DEFAULT now(),
                        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/node/migrations/V1588168331__create_tokens.sql
+++ b/node/migrations/V1588168331__create_tokens.sql
@@ -5,7 +5,6 @@ CREATE TABLE tokens (
                        status TEXT NOT NULL DEFAULT 'Active',
                        asset_state_id uuid NOT NULL references asset_states(id),
                        initial_data_json JSONB NOT NULL DEFAULT '{}',
-                       append_only_after TIMESTAMPTZ NOT NULL DEFAULT now(),
                        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/node/migrations/V1588168331__create_tokens.sql
+++ b/node/migrations/V1588168331__create_tokens.sql
@@ -4,7 +4,8 @@ CREATE TABLE tokens (
                        owner_pub_key TEXT NOT NULL,
                        status TEXT NOT NULL DEFAULT 'Active',
                        asset_state_id uuid NOT NULL references asset_states(id),
-                       additional_data_json JSONB NOT NULL DEFAULT '{}',
+                       initial_data_json JSONB NOT NULL DEFAULT '{}',
+                       append_only_after TIMESTAMPTZ NOT NULL DEFAULT now(),
                        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -28,4 +29,4 @@ EXECUTE PROCEDURE set_issue_number();
 CREATE INDEX index_tokens_uuid ON tokens (id);
 CREATE INDEX index_tokens_owner_pub_key ON tokens (owner_pub_key);
 CREATE INDEX index_tokens_status ON tokens (status);
-CREATE INDEX index_tokens_asset_state_id ON tokens (asset_state_id);
+CREATE UNIQUE INDEX index_tokens_asset_state_id_issue_number ON tokens (asset_state_id, issue_number);

--- a/node/migrations/V1588168331__create_tokens.sql
+++ b/node/migrations/V1588168331__create_tokens.sql
@@ -28,4 +28,4 @@ EXECUTE PROCEDURE set_issue_number();
 CREATE INDEX index_tokens_uuid ON tokens (id);
 CREATE INDEX index_tokens_owner_pub_key ON tokens (owner_pub_key);
 CREATE INDEX index_tokens_status ON tokens (status);
-CREATE UNIQUE INDEX index_tokens_asset_state_id_issue_number ON tokens (asset_state_id, issue_number);
+CREATE INDEX index_tokens_asset_state_id_issue_number ON tokens (asset_state_id, issue_number);

--- a/node/migrations/V1589211379__create_append_only_tables.sql
+++ b/node/migrations/V1589211379__create_append_only_tables.sql
@@ -1,12 +1,13 @@
 CREATE TABLE token_state_append_only (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     token_id uuid NOT NULL references tokens(id),
+    status text NOT NULL,
     state_data_json JSONB NOT NULL DEFAULT '{}',
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX index_token_state_append_only_uuid ON token_state_append_only (id);
-CREATE INDEX index_token_state_append_only_token_id_created_at ON token_state_append_only (token_id, created_at);
+CREATE INDEX index_token_state_append_only_token_id_status_created_at ON token_state_append_only (token_id, status, created_at);
 
 CREATE OR REPLACE VIEW tokens_view AS
 SELECT
@@ -18,6 +19,7 @@ LEFT JOIN
 (
     SELECT DISTINCT ON(token_id) *
     FROM token_state_append_only
+    WHERE status = 'Commit'
     ORDER BY token_id, created_at DESC
 ) tsao
 ON
@@ -26,12 +28,13 @@ ON
 CREATE TABLE asset_state_append_only (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
     asset_state_id uuid NOT NULL references asset_states(id),
+    status text NOT NULL,
     state_data_json JSONB NOT NULL DEFAULT '{}',
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX index_asset_state_append_only_uuid ON asset_state_append_only (id);
-CREATE INDEX index_asset_state_append_only_asset_state_id_created_at ON asset_state_append_only (asset_state_id, created_at);
+CREATE INDEX index_asset_state_append_only_asset_state_id_status_created_at ON asset_state_append_only (asset_state_id, status, created_at);
 
 CREATE OR REPLACE VIEW asset_states_view AS
 SELECT
@@ -43,6 +46,7 @@ LEFT JOIN
 (
     SELECT DISTINCT ON(asset_state_id) *
     FROM asset_state_append_only
+    WHERE status = 'Commit'
     ORDER BY asset_state_id, created_at DESC
 ) asao
 ON

--- a/node/migrations/V1589211379__create_append_only_tables.sql
+++ b/node/migrations/V1589211379__create_append_only_tables.sql
@@ -1,0 +1,72 @@
+DROP AGGREGATE IF EXISTS jsonb_merge(jsonb);
+CREATE AGGREGATE jsonb_merge(jsonb) (
+    SFUNC = jsonb_concat(jsonb, jsonb),
+    STYPE = jsonb,
+    INITCOND = '{}'
+);
+
+CREATE TABLE token_state_append_only (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    token_id uuid NOT NULL references tokens(id),
+    state_instruction JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX index_token_state_append_only_uuid ON token_state_append_only (id);
+CREATE INDEX index_token_state_append_only_token_id_created_at ON token_state_append_only (token_id, created_at);
+
+CREATE OR REPLACE VIEW tokens_view AS
+SELECT
+    t.*,
+    current_token_state.additional_data_json as additional_data_json
+FROM
+  tokens t
+JOIN
+(
+    SELECT
+        t.id,
+        t.initial_data_json || COALESCE(jsonb_merge(tsao.state_instruction), '{}') as additional_data_json
+    FROM
+        tokens t
+    LEFT JOIN
+        token_state_append_only tsao
+    ON
+        tsao.token_id = t.id
+    GROUP BY
+        t.id
+) current_token_state
+ON
+    t.id = current_token_state.id;
+
+CREATE TABLE asset_state_append_only (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    asset_state_id uuid NOT NULL references asset_states(id),
+    state_instruction JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX index_asset_state_append_only_uuid ON asset_state_append_only (id);
+CREATE INDEX index_asset_state_append_only_asset_state_id_created_at ON asset_state_append_only (asset_state_id, created_at);
+
+CREATE OR REPLACE VIEW asset_states_view AS
+SELECT
+    ast.*,
+    current_asset_state.additional_data_json as additional_data_json
+FROM
+  asset_states ast
+JOIN
+(
+    SELECT
+        ast.id,
+        ast.initial_data_json || COALESCE(jsonb_merge(asao.state_instruction), '{}') as additional_data_json
+    FROM
+        asset_states ast
+    LEFT JOIN
+        asset_state_append_only asao
+    ON
+        asao.asset_state_id = ast.id
+    GROUP BY
+        ast.id
+) current_asset_state
+ON
+    ast.id = current_asset_state.id;

--- a/node/src/db/models/asset_states.rs
+++ b/node/src/db/models/asset_states.rs
@@ -7,7 +7,7 @@ use tokio_pg_mapper::{FromTokioPostgresRow, PostgresMapper};
 use tokio_postgres::Client;
 
 #[derive(Serialize, PostgresMapper, PartialEq, Debug)]
-#[pg_mapper(table = "asset_states")]
+#[pg_mapper(table = "asset_states_view")]
 pub struct AssetState {
     pub id: uuid::Uuid,
     pub name: String,
@@ -20,11 +20,13 @@ pub struct AssetState {
     pub expiry_date: Option<DateTime<Utc>>,
     pub superseded_by: Option<uuid::Uuid>,
     pub initial_permission_bitflag: i64,
-    pub additional_data_json: Value,
+    pub initial_data_json: Value,
     pub asset_id: String,
     pub digital_asset_id: uuid::Uuid,
+    pub append_only_after: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub additional_data_json: Value,
 }
 
 /// Query paramteres for adding new asset record
@@ -38,9 +40,17 @@ pub struct NewAssetState {
     pub authorized_signers: Vec<String>,
     pub expiry_date: Option<DateTime<Utc>>,
     pub initial_permission_bitflag: i64,
-    pub additional_data_json: Value,
+    pub initial_data_json: Value,
     pub asset_id: String,
     pub digital_asset_id: uuid::Uuid,
+    pub append_only_after: Option<DateTime<Utc>>,
+}
+
+/// Query parameters for adding new token state append only
+#[derive(Default, Clone, Debug)]
+pub struct NewAssetStateAppendOnly {
+    pub asset_state_id: uuid::Uuid,
+    pub state_instruction: Value,
 }
 
 impl NewAssetState {
@@ -77,10 +87,11 @@ impl AssetState {
                 authorized_signers,
                 expiry_date,
                 initial_permission_bitflag,
-                additional_data_json,
+                initial_data_json,
                 asset_id,
-                digital_asset_id
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id";
+                digital_asset_id,
+                append_only_after
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING id";
         let stmt = client.prepare(QUERY).await?;
         let result = client
             .query_one(&stmt, &[
@@ -92,9 +103,10 @@ impl AssetState {
                 &params.authorized_signers,
                 &params.expiry_date,
                 &params.initial_permission_bitflag,
-                &params.additional_data_json,
+                &params.initial_data_json,
                 &params.asset_id,
                 &params.digital_asset_id,
+                &params.append_only_after.unwrap_or(Utc::now()),
             ])
             .await?;
 
@@ -103,16 +115,35 @@ impl AssetState {
 
     /// Load asset record
     pub async fn load(id: uuid::Uuid, client: &Client) -> Result<AssetState, DBError> {
-        let stmt = "SELECT * FROM asset_states WHERE id = $1";
+        let stmt = "SELECT * FROM asset_states_view WHERE id = $1";
         let result = client.query_one(stmt, &[&id]).await?;
         Ok(AssetState::from_row(result)?)
     }
 
     /// Find asset state record by asset id )
     pub async fn find_by_asset_id(asset_id: String, client: &Client) -> Result<Option<AssetState>, DBError> {
-        let stmt = "SELECT * FROM asset_states WHERE asset_id = $1";
+        let stmt = "SELECT * FROM asset_states_view WHERE asset_id = $1";
         let result = client.query_opt(stmt, &[&asset_id]).await?;
         Ok(result.map(AssetState::from_row).transpose()?)
+    }
+
+    // Store append only state
+    pub async fn store_append_only_state(
+        params: NewAssetStateAppendOnly,
+        client: &Client,
+    ) -> Result<uuid::Uuid, DBError>
+    {
+        const QUERY: &'static str = "
+            INSERT INTO asset_state_append_only (
+                asset_state_id,
+                state_instruction
+            ) VALUES ($1, $2) RETURNING id";
+        let stmt = client.prepare(QUERY).await?;
+        let result = client
+            .query_one(&stmt, &[&params.asset_state_id, &params.state_instruction])
+            .await?;
+
+        Ok(result.get(0))
     }
 }
 
@@ -123,6 +154,7 @@ mod test {
         db::utils::validation::*,
         test_utils::{builders::*, load_env, test_db_client},
     };
+    use serde_json::json;
     use std::collections::HashMap;
 
     const PUBKEY: &'static str = "7e6f4b801170db0bf86c9257fe562492469439556cba069a12afd1c72c585b0f";
@@ -134,13 +166,13 @@ mod test {
         let digital_asset = DigitalAssetBuilder::default().build(&client).await?;
         let tari_asset_id = "asset-id-placeholder-0976544466643335678667765432355555555445544".to_string();
 
-        let mut additional_data_json = HashMap::new();
-        additional_data_json.insert("value", true);
+        let mut initial_data_json = HashMap::new();
+        initial_data_json.insert("value", true);
         let params = NewAssetState {
             name: "AssetName".to_string(),
             description: "Description".to_string(),
             asset_issuer_pub_key: PUBKEY.to_string(),
-            additional_data_json: serde_json::to_value(additional_data_json)?,
+            initial_data_json: serde_json::to_value(initial_data_json)?,
             asset_id: tari_asset_id.clone(),
             digital_asset_id: digital_asset.id,
             ..NewAssetState::default()
@@ -155,6 +187,61 @@ mod test {
 
         let found_asset = AssetState::find_by_asset_id(tari_asset_id, &client).await?;
         assert_eq!(found_asset, Some(asset));
+
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    async fn store_append_only_state() -> anyhow::Result<()> {
+        load_env();
+        let (client, _lock) = test_db_client().await;
+        let mut initial_data_json: HashMap<&str, Value> = HashMap::new();
+        initial_data_json.insert("value", json!(true));
+        initial_data_json.insert("value2", json!(4));
+        let asset = AssetStateBuilder {
+            initial_data_json: json!(initial_data_json.clone()),
+            ..AssetStateBuilder::default()
+        }
+        .build(&client)
+        .await?;
+        assert_eq!(json!(initial_data_json), asset.initial_data_json);
+        assert_eq!(json!(initial_data_json), asset.additional_data_json);
+
+        let mut state_instruction: HashMap<&str, Value> = HashMap::new();
+        state_instruction.insert("value", Value::Null);
+        state_instruction.insert("value2", json!(8));
+        state_instruction.insert("value3", json!(2));
+        AssetState::store_append_only_state(
+            NewAssetStateAppendOnly {
+                asset_state_id: asset.id,
+                state_instruction: json!(state_instruction),
+            },
+            &client,
+        )
+        .await?;
+        let mut expected_data = initial_data_json.clone();
+        expected_data.insert("value", Value::Null);
+        expected_data.insert("value2", json!(8));
+        expected_data.insert("value3", json!(2));
+        let asset = AssetState::load(asset.id, &client).await?;
+        assert_eq!(json!(expected_data), asset.additional_data_json);
+
+        let mut state_instruction: HashMap<&str, Value> = HashMap::new();
+        state_instruction.insert("value", json!(false));
+        state_instruction.insert("value3", Value::Null);
+        AssetState::store_append_only_state(
+            NewAssetStateAppendOnly {
+                asset_state_id: asset.id,
+                state_instruction: json!(state_instruction),
+            },
+            &client,
+        )
+        .await?;
+        expected_data.insert("value", json!(false));
+        expected_data.insert("value2", json!(8));
+        expected_data.insert("value3", Value::Null);
+        let asset = AssetState::load(asset.id, &client).await?;
+        assert_eq!(json!(expected_data), asset.additional_data_json);
 
         Ok(())
     }

--- a/node/src/db/models/asset_states.rs
+++ b/node/src/db/models/asset_states.rs
@@ -157,7 +157,6 @@ mod test {
         test_utils::{builders::*, load_env, test_db_client},
     };
     use serde_json::json;
-    use std::collections::HashMap;
 
     const PUBKEY: &'static str = "7e6f4b801170db0bf86c9257fe562492469439556cba069a12afd1c72c585b0f";
 
@@ -168,13 +167,11 @@ mod test {
         let digital_asset = DigitalAssetBuilder::default().build(&client).await?;
         let tari_asset_id = "asset-id-placeholder-0976544466643335678667765432355555555445544".to_string();
 
-        let mut initial_data = HashMap::new();
-        initial_data.insert("value", true);
         let params = NewAssetState {
             name: "AssetName".to_string(),
             description: "Description".to_string(),
             asset_issuer_pub_key: PUBKEY.to_string(),
-            initial_data_json: serde_json::to_value(initial_data)?,
+            initial_data_json: json!({"value": true}),
             asset_id: tari_asset_id.clone(),
             digital_asset_id: digital_asset.id,
             ..NewAssetState::default()

--- a/node/src/db/models/enums.rs
+++ b/node/src/db/models/enums.rs
@@ -68,10 +68,17 @@ macro_rules! string_enum {
     }
 }
 
+string_enum! { AccessResource [Api, Wallet]}
 string_enum! { AssetStatus [Active, Retired]}
+string_enum! { AppendOnlyStatus [Commit, PreCommit, Prepare]}
 string_enum! { CommitteeMode [Public, Creator]}
 string_enum! { TokenStatus [Active, Retired]}
-string_enum! { AccessResource [Api, Wallet]}
+
+impl Default for AppendOnlyStatus {
+    fn default() -> AppendOnlyStatus {
+        AppendOnlyStatus::Prepare
+    }
+}
 
 impl Default for CommitteeMode {
     fn default() -> CommitteeMode {

--- a/node/src/db/models/tokens.rs
+++ b/node/src/db/models/tokens.rs
@@ -7,24 +7,34 @@ use tokio_pg_mapper::{FromTokioPostgresRow, PostgresMapper};
 use tokio_postgres::Client;
 
 #[derive(Serialize, PostgresMapper)]
-#[pg_mapper(table = "tokens")]
+#[pg_mapper(table = "tokens_view")]
 pub struct Token {
     pub id: uuid::Uuid,
     pub issue_number: i64,
     pub owner_pub_key: String,
     pub status: TokenStatus,
     pub asset_state_id: uuid::Uuid,
-    pub additional_data_json: Value,
+    pub initial_data_json: Value,
+    pub append_only_after: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub additional_data_json: Value,
 }
 
-/// Query paramteres for adding new token record
+/// Query parameters for adding new token record
 #[derive(Default, Clone, Debug)]
 pub struct NewToken {
     pub owner_pub_key: String,
     pub asset_state_id: uuid::Uuid,
-    pub additional_data_json: Value,
+    pub initial_data_json: Value,
+    pub append_only_after: Option<DateTime<Utc>>,
+}
+
+/// Query parameters for adding new token state append only
+#[derive(Default, Clone, Debug)]
+pub struct NewTokenAppendOnly {
+    pub token_id: uuid::Uuid,
+    pub state_instruction: Value,
 }
 
 impl Token {
@@ -34,14 +44,16 @@ impl Token {
             INSERT INTO tokens (
                 owner_pub_key,
                 asset_state_id,
-                additional_data_json
-            ) VALUES ($1, $2, $3) RETURNING id";
+                initial_data_json,
+                append_only_after
+            ) VALUES ($1, $2, $3, $4) RETURNING id";
         let stmt = client.prepare(QUERY).await?;
         let result = client
             .query_one(&stmt, &[
                 &params.owner_pub_key,
                 &params.asset_state_id,
-                &params.additional_data_json,
+                &params.initial_data_json,
+                &params.append_only_after.unwrap_or(Utc::now()),
             ])
             .await?;
 
@@ -50,9 +62,24 @@ impl Token {
 
     /// Load token record
     pub async fn load(id: uuid::Uuid, client: &Client) -> Result<Token, DBError> {
-        let stmt = "SELECT * FROM tokens WHERE id = $1";
+        let stmt = "SELECT * FROM tokens_view WHERE id = $1";
         let result = client.query_one(stmt, &[&id]).await?;
         Ok(Token::from_row(result)?)
+    }
+
+    // Store append only state
+    pub async fn store_append_only_state(params: NewTokenAppendOnly, client: &Client) -> Result<uuid::Uuid, DBError> {
+        const QUERY: &'static str = "
+            INSERT INTO token_state_append_only (
+                token_id,
+                state_instruction
+            ) VALUES ($1, $2) RETURNING id";
+        let stmt = client.prepare(QUERY).await?;
+        let result = client
+            .query_one(&stmt, &[&params.token_id, &params.state_instruction])
+            .await?;
+
+        Ok(result.get(0))
     }
 }
 
@@ -60,6 +87,7 @@ impl Token {
 mod test {
     use super::*;
     use crate::test_utils::{builders::*, load_env, test_db_client};
+    use serde_json::json;
     use std::collections::HashMap;
     const PUBKEY: &'static str = "7e6f4b801170db0bf86c9257fe562492469439556cba069a12afd1c72c585b0f";
 
@@ -69,13 +97,13 @@ mod test {
         let (client, _lock) = test_db_client().await;
         let asset = AssetStateBuilder::default().build(&client).await?;
         let asset2 = AssetStateBuilder::default().build(&client).await?;
-        let mut additional_data_json = HashMap::new();
-        additional_data_json.insert("value", true);
+        let mut initial_data_json = HashMap::new();
+        initial_data_json.insert("value", true);
 
         let params = NewToken {
             owner_pub_key: PUBKEY.to_string(),
             asset_state_id: asset.id,
-            additional_data_json: serde_json::to_value(additional_data_json.clone())?,
+            initial_data_json: serde_json::to_value(initial_data_json.clone())?,
             ..NewToken::default()
         };
         let token_id = Token::insert(params, &client).await?;
@@ -87,7 +115,7 @@ mod test {
         let params = NewToken {
             owner_pub_key: PUBKEY.to_string(),
             asset_state_id: asset.id,
-            additional_data_json: serde_json::to_value(additional_data_json.clone())?,
+            initial_data_json: serde_json::to_value(initial_data_json.clone())?,
             ..NewToken::default()
         };
         let token_id = Token::insert(params, &client).await?;
@@ -99,7 +127,7 @@ mod test {
         let params = NewToken {
             owner_pub_key: PUBKEY.to_string(),
             asset_state_id: asset2.id,
-            additional_data_json: serde_json::to_value(additional_data_json)?,
+            initial_data_json: serde_json::to_value(initial_data_json)?,
             ..NewToken::default()
         };
         let token_id = Token::insert(params, &client).await?;
@@ -107,6 +135,61 @@ mod test {
         assert_eq!(token.owner_pub_key, PUBKEY.to_string());
         assert_eq!(token.asset_state_id, asset2.id);
         assert_eq!(token.issue_number, 1);
+
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    async fn store_append_only_state() -> anyhow::Result<()> {
+        load_env();
+        let (client, _lock) = test_db_client().await;
+        let mut initial_data_json: HashMap<&str, Value> = HashMap::new();
+        initial_data_json.insert("value", json!(true));
+        initial_data_json.insert("value2", json!(4));
+        let token = TokenBuilder {
+            initial_data_json: json!(initial_data_json.clone()),
+            ..TokenBuilder::default()
+        }
+        .build(&client)
+        .await?;
+        assert_eq!(json!(initial_data_json), token.initial_data_json);
+        assert_eq!(json!(initial_data_json), token.additional_data_json);
+
+        let mut state_instruction: HashMap<&str, Value> = HashMap::new();
+        state_instruction.insert("value", Value::Null);
+        state_instruction.insert("value2", json!(8));
+        state_instruction.insert("value3", json!(2));
+        Token::store_append_only_state(
+            NewTokenAppendOnly {
+                token_id: token.id,
+                state_instruction: json!(state_instruction),
+            },
+            &client,
+        )
+        .await?;
+        let mut expected_data = initial_data_json.clone();
+        expected_data.insert("value", Value::Null);
+        expected_data.insert("value2", json!(8));
+        expected_data.insert("value3", json!(2));
+        let token = Token::load(token.id, &client).await?;
+        assert_eq!(json!(expected_data), token.additional_data_json);
+
+        let mut state_instruction: HashMap<&str, Value> = HashMap::new();
+        state_instruction.insert("value", json!(false));
+        state_instruction.insert("value3", Value::Null);
+        Token::store_append_only_state(
+            NewTokenAppendOnly {
+                token_id: token.id,
+                state_instruction: json!(state_instruction),
+            },
+            &client,
+        )
+        .await?;
+        expected_data.insert("value", json!(false));
+        expected_data.insert("value2", json!(8));
+        expected_data.insert("value3", Value::Null);
+        let token = Token::load(token.id, &client).await?;
+        assert_eq!(json!(expected_data), token.additional_data_json);
 
         Ok(())
     }

--- a/node/src/db/models/tokens.rs
+++ b/node/src/db/models/tokens.rs
@@ -86,7 +86,6 @@ mod test {
     use super::*;
     use crate::test_utils::{builders::*, load_env, test_db_client};
     use serde_json::json;
-    use std::collections::HashMap;
     const PUBKEY: &'static str = "7e6f4b801170db0bf86c9257fe562492469439556cba069a12afd1c72c585b0f";
 
     #[actix_rt::test]
@@ -95,13 +94,11 @@ mod test {
         let (client, _lock) = test_db_client().await;
         let asset = AssetStateBuilder::default().build(&client).await?;
         let asset2 = AssetStateBuilder::default().build(&client).await?;
-        let mut initial_data = HashMap::new();
-        initial_data.insert("value", true);
 
         let params = NewToken {
             owner_pub_key: PUBKEY.to_string(),
             asset_state_id: asset.id,
-            initial_data_json: serde_json::to_value(initial_data.clone())?,
+            initial_data_json: json!({"value": true}),
             ..NewToken::default()
         };
         let token_id = Token::insert(params, &client).await?;
@@ -113,7 +110,7 @@ mod test {
         let params = NewToken {
             owner_pub_key: PUBKEY.to_string(),
             asset_state_id: asset.id,
-            initial_data_json: serde_json::to_value(initial_data.clone())?,
+            initial_data_json: json!({"value": true}),
             ..NewToken::default()
         };
         let token_id = Token::insert(params, &client).await?;
@@ -125,7 +122,7 @@ mod test {
         let params = NewToken {
             owner_pub_key: PUBKEY.to_string(),
             asset_state_id: asset2.id,
-            initial_data_json: serde_json::to_value(initial_data)?,
+            initial_data_json: json!({"value": true}),
             ..NewToken::default()
         };
         let token_id = Token::insert(params, &client).await?;

--- a/node/src/test_utils/builders/asset_state_builder.rs
+++ b/node/src/test_utils/builders/asset_state_builder.rs
@@ -16,9 +16,10 @@ pub struct AssetStateBuilder {
     pub authorized_signers: Vec<String>,
     pub expiry_date: Option<DateTime<Utc>>,
     pub initial_permission_bitflag: i64,
-    pub additional_data_json: Value,
+    pub initial_data_json: Value,
     pub digital_asset_id: Option<Uuid>,
     pub asset_id: String,
+    pub append_only_after: Option<DateTime<Utc>>,
     #[doc(hidden)]
     pub __non_exhaustive: (),
 }
@@ -36,9 +37,10 @@ impl Default for AssetStateBuilder {
             authorized_signers: Vec::new(),
             expiry_date: None,
             initial_permission_bitflag: 0,
-            additional_data_json: serde_json::from_str("{}").unwrap(),
+            initial_data_json: serde_json::from_str("{}").unwrap(),
             digital_asset_id: None,
             asset_id: format!("asset-id-placeholder-{}", x).into(), // TODO: Use a real asset ID here for consistency
+            append_only_after: None,
             __non_exhaustive: (),
         }
     }
@@ -60,8 +62,9 @@ impl AssetStateBuilder {
             authorized_signers: self.authorized_signers.to_owned(),
             expiry_date: self.expiry_date,
             initial_permission_bitflag: self.initial_permission_bitflag,
-            additional_data_json: self.additional_data_json.to_owned(),
+            initial_data_json: self.initial_data_json.to_owned(),
             asset_id: self.asset_id.to_owned(),
+            append_only_after: self.append_only_after.to_owned(),
             digital_asset_id,
         };
         let asset_id = AssetState::insert(params, client).await?;

--- a/node/src/test_utils/builders/asset_state_builder.rs
+++ b/node/src/test_utils/builders/asset_state_builder.rs
@@ -19,7 +19,6 @@ pub struct AssetStateBuilder {
     pub initial_data_json: Value,
     pub digital_asset_id: Option<Uuid>,
     pub asset_id: String,
-    pub append_only_after: Option<DateTime<Utc>>,
     #[doc(hidden)]
     pub __non_exhaustive: (),
 }
@@ -40,7 +39,6 @@ impl Default for AssetStateBuilder {
             initial_data_json: serde_json::from_str("{}").unwrap(),
             digital_asset_id: None,
             asset_id: format!("asset-id-placeholder-{}", x).into(), // TODO: Use a real asset ID here for consistency
-            append_only_after: None,
             __non_exhaustive: (),
         }
     }
@@ -64,7 +62,6 @@ impl AssetStateBuilder {
             initial_permission_bitflag: self.initial_permission_bitflag,
             initial_data_json: self.initial_data_json.to_owned(),
             asset_id: self.asset_id.to_owned(),
-            append_only_after: self.append_only_after.to_owned(),
             digital_asset_id,
         };
         let asset_id = AssetState::insert(params, client).await?;

--- a/node/src/test_utils/builders/token_builder.rs
+++ b/node/src/test_utils/builders/token_builder.rs
@@ -1,5 +1,6 @@
 use super::AssetStateBuilder;
 use crate::db::models::*;
+use chrono::{DateTime, Utc};
 use rand::prelude::*;
 use serde_json::Value;
 use tokio_postgres::Client;
@@ -9,7 +10,8 @@ use uuid::Uuid;
 pub struct TokenBuilder {
     pub owner_pub_key: String,
     pub asset_state_id: Option<Uuid>,
-    pub additional_data_json: Value,
+    pub initial_data_json: Value,
+    pub append_only_after: Option<DateTime<Utc>>,
     #[doc(hidden)]
     pub __non_exhaustive: (),
 }
@@ -20,7 +22,8 @@ impl Default for TokenBuilder {
         Self {
             owner_pub_key: format!("7e6f4b801170db0bf86c9257fe562492469439556cba069a12afd1c72c585b0{}", x).into(),
             asset_state_id: None,
-            additional_data_json: serde_json::from_str("{}").unwrap(),
+            initial_data_json: serde_json::from_str("{}").unwrap(),
+            append_only_after: None,
             __non_exhaustive: (),
         }
     }
@@ -36,7 +39,8 @@ impl TokenBuilder {
 
         let params = NewToken {
             owner_pub_key: self.owner_pub_key.to_owned(),
-            additional_data_json: self.additional_data_json.to_owned(),
+            initial_data_json: self.initial_data_json.to_owned(),
+            append_only_after: self.append_only_after,
             asset_state_id,
         };
         let token_id = Token::insert(params, client).await?;

--- a/node/src/test_utils/builders/token_builder.rs
+++ b/node/src/test_utils/builders/token_builder.rs
@@ -1,6 +1,5 @@
 use super::AssetStateBuilder;
 use crate::db::models::*;
-use chrono::{DateTime, Utc};
 use rand::prelude::*;
 use serde_json::Value;
 use tokio_postgres::Client;
@@ -11,7 +10,6 @@ pub struct TokenBuilder {
     pub owner_pub_key: String,
     pub asset_state_id: Option<Uuid>,
     pub initial_data_json: Value,
-    pub append_only_after: Option<DateTime<Utc>>,
     #[doc(hidden)]
     pub __non_exhaustive: (),
 }
@@ -23,7 +21,6 @@ impl Default for TokenBuilder {
             owner_pub_key: format!("7e6f4b801170db0bf86c9257fe562492469439556cba069a12afd1c72c585b0{}", x).into(),
             asset_state_id: None,
             initial_data_json: serde_json::from_str("{}").unwrap(),
-            append_only_after: None,
             __non_exhaustive: (),
         }
     }
@@ -40,7 +37,6 @@ impl TokenBuilder {
         let params = NewToken {
             owner_pub_key: self.owner_pub_key.to_owned(),
             initial_data_json: self.initial_data_json.to_owned(),
-            append_only_after: self.append_only_after,
             asset_state_id,
         };
         let token_id = Token::insert(params, client).await?;


### PR DESCRIPTION
## Description
The models (tokens, asset states) have their state appended to an append only table between checkpoints when the state is rolled up. This pull request adds a new append only table for each and a view that reflects the latest version of the data. In the future we should be able to handle the roll up logic by using the current additional_data_json from the view.

For replaying the data changes to nodes that need to catch up: they should be able to figure out which token is being used by using the asset ID (figured out via the asset state join -> digital asset) and the issue number. The data isn't denormalized to include either as they can be found via the joins.

## Motivation and Context
We don't want to allow changes to the state between checkpoints so this allows us to change the data without modifying it directly. These can be replayed to see the current state of the data.

## How Has This Been Tested?
I've added new tests and manually tested things a bit with the view.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
