### PR TITLE
Install actix HTTP API for templates

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -50,3 +50,4 @@ lazy_static = "1.4"
 tempdir = "0.3.7"
 multiaddr = {version = "0.7.0", package = "parity-multiaddr"}
 tari_test_utils = "^0.0"
+pretty_env_logger = "0.4"

--- a/node/src/api/errors/api_error.rs
+++ b/node/src/api/errors/api_error.rs
@@ -1,7 +1,6 @@
 use super::*;
-use crate::db::utils::errors::DBError;
+use crate::{db::utils::errors::DBError, types::errors::TypeError};
 use actix_web::{error::ResponseError, http::StatusCode, HttpResponse};
-use log::error;
 use serde_json::json;
 use thiserror::Error;
 
@@ -9,6 +8,8 @@ use thiserror::Error;
 pub enum ApiError {
     #[error("DB error: {0}")]
     DBError(#[from] DBError),
+    #[error("Incorrect value: {0}")]
+    Type(#[from] TypeError),
     #[error("Contract error: {0}")]
     Contract(#[from] anyhow::Error),
     #[error("Application error: {0}")]
@@ -97,6 +98,11 @@ impl ApiError {
                 },
                 _ => generic_error_response_data,
             },
+            ApiError::Type(err) => ResponseData {
+                status_code: StatusCode::BAD_REQUEST,
+                error_response: HttpResponse::build(StatusCode::BAD_REQUEST)
+                    .json(json!({ "error": err.to_string() })),
+            },
             ApiError::Contract(err) => ResponseData {
                 status_code: StatusCode::INTERNAL_SERVER_ERROR,
                 error_response: HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
@@ -113,8 +119,10 @@ impl ResponseError for ApiError {
 
     fn error_response(&self) -> HttpResponse {
         let response_data = self.load_response_data();
-        if response_data.status_code != StatusCode::NOT_FOUND {
-            error!("{:?}", self);
+        if response_data.status_code.is_server_error() {
+            log::error!(target: LOG_TARGET, "Server error: {}", self);
+        } else if response_data.status_code.is_client_error() {
+            log::info!(target: LOG_TARGET, "Client error: {}", self);
         }
 
         response_data.error_response

--- a/node/src/api/errors/mod.rs
+++ b/node/src/api/errors/mod.rs
@@ -3,3 +3,5 @@ pub use self::{api_error::*, application_error::*, auth_error::*};
 mod api_error;
 mod application_error;
 mod auth_error;
+
+pub(crate) use super::LOG_TARGET;

--- a/node/src/api/mod.rs
+++ b/node/src/api/mod.rs
@@ -5,3 +5,5 @@ pub mod middleware;
 pub mod models;
 pub mod routing;
 pub mod server;
+
+pub(crate) const LOG_TARGET: &'static str = "validator_node::api";

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
     let node_config = NodeConfig::load_from(&config, true)?;
 
     match args.command {
-        Commands::Start => actix_main(node_config).await?,
+        Commands::Start => actix_main(node_config, install_templates).await?,
         Commands::Init => {
             println!("Initializing database {:?}", node_config.postgres.dbname);
             utils::db::create_database(node_config).await?;

--- a/node/src/template/actix.rs
+++ b/node/src/template/actix.rs
@@ -188,7 +188,7 @@ mod test {
 
     #[actix_rt::test]
     async fn test_actix_template_routes() {
-        pretty_env_logger::init();
+        let _ = pretty_env_logger::try_init();
         let mut app = test::init_service(
             App::new()
                 .wrap(Logger::default())
@@ -272,8 +272,8 @@ mod test {
 
     #[actix_rt::test]
     async fn full_stack_server() {
+        let _ = pretty_env_logger::try_init();
         let pool = actix_test_pool();
-        pretty_env_logger::init();
         let srv = test::start(move || {
             App::new()
                 .app_data(pool.clone())

--- a/node/src/template/actix.rs
+++ b/node/src/template/actix.rs
@@ -1,45 +1,41 @@
-use super::{Contracts, Template, TemplateContext};
+use super::{Contracts, Template, TemplateContext, LOG_TARGET};
 use crate::{
     api::errors::{ApiError, ApplicationError},
     db::utils::errors::DBError,
     types::{AssetID, TemplateID, TokenID},
 };
 use actix_web::{dev::Payload, web, web::Data, FromRequest, HttpRequest};
-use anyhow::Result;
 use deadpool_postgres::Pool;
 use futures::future::{err, FutureExt, LocalBoxFuture};
+use log::info;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub(crate) struct AssetCallParams {
-    features: [char; 4],
-    raid_id: [char; 15],
-    hash: [char; 32],
+    features: String,
+    raid_id: String,
+    hash: String,
 }
 impl AssetCallParams {
-    pub fn asset_id(&self, tpl: &TemplateID) -> Result<AssetID> {
+    pub fn asset_id(&self, tpl: &TemplateID) -> Result<AssetID, ApiError> {
         let template_id = tpl.to_hex();
-        let features: String = self.features.iter().collect();
-        let raid_id: String = self.raid_id.iter().collect();
-        let hash: String = self.hash.iter().collect();
-        Ok(format!("{}{}{}.{}", template_id, features, raid_id, hash).parse()?)
+        Ok(format!("{}{}{}.{}", template_id, self.features, self.raid_id, self.hash).parse()?)
     }
 }
 
 #[derive(Deserialize)]
 pub(crate) struct TokenCallParams {
-    features: [char; 4],
-    raid_id: [char; 15],
-    hash: [char; 32],
-    uid: [char; 32],
+    features: String,
+    raid_id: String,
+    hash: String,
+    uid: String,
 }
 impl TokenCallParams {
-    pub fn token_id(&self, tpl: &TemplateID) -> Result<TokenID> {
-        let uid: String = self.uid.iter().collect();
-        Ok(format!("{}{}", self.asset_id(tpl)?, uid).parse()?)
+    pub fn token_id(&self, tpl: &TemplateID) -> Result<TokenID, ApiError> {
+        Ok(format!("{}{}", self.asset_id(tpl)?, self.uid).parse()?)
     }
 
-    pub fn asset_id(&self, tpl: &TemplateID) -> Result<AssetID> {
+    pub fn asset_id(&self, tpl: &TemplateID) -> Result<AssetID, ApiError> {
         AssetCallParams::from(self).asset_id(tpl)
     }
 }
@@ -54,16 +50,29 @@ impl From<&TokenCallParams> for AssetCallParams {
 }
 
 pub fn install_template<T: Template>(app: &mut web::ServiceConfig) {
-    app.service(
-        web::scope(format!("/asset_call/{}/{{features}}/{{raid_id}}/{{hash}}/", T::id()).as_str())
-            .app_data(T::id())
-            .configure(<T::AssetContracts as Contracts>::setup_actix_routes),
+    let asset_root = format!("/asset_call/{}/{{features}}/{{raid_id}}/{{hash}}", T::id());
+    info!(
+        target: LOG_TARGET,
+        "template={}, installing assets API root {}",
+        T::id(),
+        asset_root
     );
-
     app.service(
-        web::scope(format!("/token_call/{}/{{features}}/{{raid_id}}/{{hash}}/{{uid}}", T::id()).as_str())
-            .app_data(T::id())
-            .configure(<T::TokenContracts as Contracts>::setup_actix_routes),
+        web::scope(asset_root.as_str())
+            .data(T::id())
+            .configure(|app| <T::AssetContracts as Contracts>::setup_actix_routes(T::id(), app)),
+    );
+    let token_root = format!("/token_call/{}/{{features}}/{{raid_id}}/{{hash}}/{{uid}}", T::id());
+    info!(
+        target: LOG_TARGET,
+        "template={}, installing tokens API root {}",
+        T::id(),
+        token_root
+    );
+    app.service(
+        web::scope(token_root.as_str())
+            .data(T::id())
+            .configure(|app| <T::TokenContracts as Contracts>::setup_actix_routes(T::id(), app)),
     );
 }
 
@@ -109,8 +118,9 @@ mod test {
     use super::*;
     use crate::{
         db::models::tokens::*,
-        test_utils::{builders::*, test_db_client},
+        test_utils::{actix_test_pool, builders::*, test_db_client},
     };
+    use actix_web::{web, HttpResponse, Result};
 
     const NODE_ID: [u8; 6] = [0, 1, 2, 3, 4, 5];
 
@@ -138,5 +148,164 @@ mod test {
             let created = context.create_token(token.clone()).await.unwrap();
             assert_eq!(token.token_id, created.token_id);
         }
+    }
+
+    /// *** Test template implementation - low level API testins *****
+
+    // Asset contracts
+    async fn asset_handler(path: web::Path<AssetCallParams>, tpl: web::Data<TemplateID>) -> Result<HttpResponse> {
+        Ok(HttpResponse::Ok().body(path.asset_id(&tpl)?.to_string()))
+    }
+    enum AssetConracts {}
+    impl Contracts for AssetConracts {
+        fn setup_actix_routes(tpl: TemplateID, scope: &mut web::ServiceConfig) {
+            log::info!("template={}, registering asset routes", tpl);
+            scope.service(web::resource("test").route(web::post().to(asset_handler)));
+        }
+    }
+    // Token contracts
+    async fn token_handler(path: web::Path<TokenCallParams>, tpl: web::Data<TemplateID>) -> Result<HttpResponse> {
+        Ok(HttpResponse::Ok().body(path.token_id(&tpl)?.to_string()))
+    }
+    enum TokenConracts {}
+    impl Contracts for TokenConracts {
+        fn setup_actix_routes(_: TemplateID, scope: &mut web::ServiceConfig) {
+            scope.service(web::resource("test").route(web::post().to(token_handler)));
+        }
+    }
+    struct TestTemplate;
+    impl Template for TestTemplate {
+        type AssetContracts = AssetConracts;
+        type TokenContracts = TokenConracts;
+
+        fn id() -> TemplateID {
+            65536.into()
+        }
+    }
+    /// *** End of Test template implementation *****
+    use actix_web::{http::StatusCode, middleware::Logger, test, App};
+    use pretty_env_logger;
+
+    #[actix_rt::test]
+    async fn test_actix_template_routes() {
+        pretty_env_logger::init();
+        let mut app = test::init_service(
+            App::new()
+                .wrap(Logger::default())
+                .configure(install_template::<TestTemplate>),
+        )
+        .await;
+
+        use actix_web::http::Method;
+        let tpl = TestTemplate::id();
+        let req_resp = [
+            // root path
+            (Method::GET, "/".to_string(), StatusCode::NOT_FOUND),
+            (Method::POST, "/".to_string(), StatusCode::NOT_FOUND),
+            // asset routes
+            (Method::POST, format!("/asset_call/{}/test", tpl), StatusCode::NOT_FOUND),
+            (
+                Method::POST,
+                format!("/asset_call/{}/{:04X}/{:015X}/{:032X}/test", tpl, 1, 2, 3),
+                StatusCode::OK,
+            ),
+            (
+                Method::GET,
+                format!("/asset_call/{}/{:04X}/{:015X}/{:032X}/test", tpl, 1, 2, 3),
+                StatusCode::METHOD_NOT_ALLOWED,
+            ),
+            (
+                Method::POST,
+                format!("/asset_call/{}/{:04X}/{:015X}/{:032X}/", tpl, 1, 2, 3),
+                StatusCode::NOT_FOUND,
+            ),
+            (Method::POST, "/asset_call/".to_string(), StatusCode::NOT_FOUND),
+            (Method::POST, format!("/asset_call/{}", tpl), StatusCode::NOT_FOUND),
+            (
+                Method::POST,
+                format!("/asset_call/{}/{:04X}/{:015X}/{:032X}/test", "1.0", 1, 2, 3),
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                Method::POST,
+                format!("/asset_call/{}/a/b/c/test", tpl),
+                StatusCode::BAD_REQUEST,
+            ),
+            // token routes
+            (
+                Method::POST,
+                format!("/token_call/{}/{:04X}/{:015X}/{:032X}/{:032X}/test", tpl, 1, 2, 3, 4),
+                StatusCode::OK,
+            ),
+            (
+                Method::GET,
+                format!("/token_call/{}/{:04X}/{:015X}/{:032X}/{:032X}/test", tpl, 1, 2, 3, 4),
+                StatusCode::METHOD_NOT_ALLOWED,
+            ),
+            (
+                Method::POST,
+                format!("/token_call/{}/{:04X}/{:015X}/{:032X}/{:032X}/", tpl, 1, 2, 3, 4),
+                StatusCode::NOT_FOUND,
+            ),
+            (Method::POST, "/token_call/".to_string(), StatusCode::NOT_FOUND),
+            (Method::POST, format!("/token_call/{}", tpl), StatusCode::NOT_FOUND),
+            (
+                Method::POST,
+                format!("/token_call/{}/{:04X}/{:015X}/{:032X}/{:032X}/test", "1.0", 1, 2, 3, 4),
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                Method::POST,
+                format!("/token_call/{}/a/b/c/d/test", tpl),
+                StatusCode::BAD_REQUEST,
+            ),
+        ];
+
+        for (method, uri, code) in &req_resp {
+            let req = test::TestRequest::with_uri(uri.as_str())
+                .method((*method).clone())
+                .to_request();
+            let resp = test::call_service(&mut app, req).await;
+            assert_eq!(resp.status(), *code, "POST {}", uri);
+        }
+    }
+
+    #[actix_rt::test]
+    async fn full_stack_server() {
+        let pool = actix_test_pool();
+        pretty_env_logger::init();
+        let srv = test::start(move || {
+            App::new()
+                .app_data(pool.clone())
+                .wrap(Logger::default())
+                .configure(install_template::<TestTemplate>)
+        });
+
+        let tpl = TestTemplate::id();
+        let asset: AssetID = format!("{}{:04X}{:015X}.{:032X}", tpl.to_hex(), 1, 2, 3)
+            .parse()
+            .unwrap();
+        let token: TokenID = format!("{}{:04X}{:015X}.{:032X}{:032X}", tpl.to_hex(), 1, 2, 3, 4)
+            .parse()
+            .unwrap();
+
+        let mut resp = srv
+            .post(format!("/asset_call/{}/{:04X}/{:015X}/{:032X}/test", tpl, 1, 2, 3))
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+        assert_eq!(resp.body().await.unwrap(), asset.to_string());
+
+        let mut resp = srv
+            .post(format!(
+                "/token_call/{}/{:04X}/{:015X}/{:032X}/{:032X}/test",
+                tpl, 1, 2, 3, 4
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+        assert_eq!(resp.body().await.unwrap(), token.to_string());
     }
 }

--- a/node/src/template/mod.rs
+++ b/node/src/template/mod.rs
@@ -17,6 +17,7 @@
 // we shall provide some custom build script which disallows installing templates using unsafe on a node
 
 use crate::types::TemplateID;
+use actix_web::web;
 
 mod errors;
 pub use errors::TemplateError;
@@ -27,8 +28,13 @@ pub mod single_use_tokens;
 mod context;
 pub use context::{AssetTemplateContext, TemplateContext, TokenTemplateContext};
 
+const LOG_TARGET: &'static str = "validator_node::template";
+
 pub trait Contracts {
-    fn setup_actix_routes(scope: &mut actix_web::web::ServiceConfig);
+    fn setup_actix_routes(tpl: TemplateID, scope: &mut web::ServiceConfig);
+}
+impl Contracts for () {
+    fn setup_actix_routes(_: TemplateID, _: &mut web::ServiceConfig) {}
 }
 
 #[async_trait::async_trait]

--- a/node/src/template/single_use_tokens.rs
+++ b/node/src/template/single_use_tokens.rs
@@ -81,6 +81,7 @@ mod expanded_macros {
         api::errors::{ApiError, ApplicationError},
         db::models::transactions::*,
     };
+    use log::info;
     use serde::{Deserialize, Serialize};
 
     ////// impl #[contract(asset)] for issue_tokens()
@@ -140,7 +141,8 @@ mod expanded_macros {
     ////// impl #[derive(Contracts)] for AssetContracts
 
     impl Contracts for AssetContracts {
-        fn setup_actix_routes(scope: &mut web::ServiceConfig) {
+        fn setup_actix_routes(tpl: TemplateID, scope: &mut web::ServiceConfig) {
+            info!("template={}, installing assets API issue_tokens", tpl);
             scope.service(web::resource("/issue_tokens").route(web::post().to(issue_tokens_actix)));
         }
     }
@@ -207,7 +209,8 @@ mod expanded_macros {
     use actix_web::web;
 
     impl Contracts for TokenContracts {
-        fn setup_actix_routes(scope: &mut web::ServiceConfig) {
+        fn setup_actix_routes(tpl: TemplateID, scope: &mut web::ServiceConfig) {
+            info!("template={}, installing token API transfer_token", tpl);
             scope.service(web::resource("/transfer_token").route(web::post().to(transfer_token_actix)));
         }
     }


### PR DESCRIPTION
## Description

Install templates into actix server via install_template method. This PR is installing SingleUseToken template into main server, also adding template service unit tests as well as functional actix tests.
There is also small improvement to errors logging.

## Motivation and Context

Continuation of PR#1, also extending test coverage and fixing few issues by the way.

## How Has This Been Tested?

Automated tests covering /asset_call and /token_call endpoints with stub data.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [X] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
