### PR TITLE
Instruction state transitions

### DIFF
--- a/node/src/api/server.rs
+++ b/node/src/api/server.rs
@@ -36,7 +36,7 @@ pub async fn actix_main(
         config.actix.addr().to_socket_addrs()?.next().unwrap()
     );
 
-    let mut consensus_processor = ConsensusProcessor::new(config.clone());
+    let mut consensus_processor = ConsensusProcessor::new(config.clone(), metrics_addr.clone());
     let (kill_sender, kill_receiver) = mpsc::channel::<()>();
     // TODO: spawn consensus processors in separate Runtime
     actix_rt::spawn(async move {

--- a/node/src/consensus/consensus_worker.rs
+++ b/node/src/consensus/consensus_worker.rs
@@ -1,29 +1,40 @@
 use super::{communications::*, errors::ConsensusError, ConsensusCommittee};
 use crate::{
     config::NodeConfig,
-    consensus::LOG_TARGET,
-    db::utils::db::db_client,
-    types::{consensus::CommitteeState, NodeID},
+    consensus::{instruction_state, instruction_state::InstructionTransitionContext, LOG_TARGET},
+    db::{
+        models::{consensus::*, AssetState, ProposalStatus, Token, ViewStatus},
+        utils::{db::db_client, errors::DBError},
+    },
+    metrics::Metrics,
+    types::{consensus::CommitteeState, InstructionID, NodeID},
 };
+
+use actix::Addr;
 use deadpool_postgres::Client;
 use log::{error, warn};
 
 pub struct ConsensusWorker {
     node_config: NodeConfig,
+    metrics_addr: Option<Addr<Metrics>>,
 }
 
 impl ConsensusWorker {
-    pub fn new(node_config: NodeConfig) -> Result<Self, ConsensusError> {
-        Ok(ConsensusWorker { node_config })
+    pub fn new(node_config: NodeConfig, metrics_addr: Option<Addr<Metrics>>) -> Result<Self, ConsensusError> {
+        Ok(ConsensusWorker {
+            node_config,
+            metrics_addr,
+        })
     }
 
     pub async fn work(&self, node_id: NodeID) -> Result<(), ConsensusError> {
         let config = self.node_config.clone();
+        let metrics_address = self.metrics_addr.clone();
         let client = db_client(&config)
             .await
             .expect("Validator node unable to load db client");
         actix_rt::spawn(async move {
-            if let Err(e) = ConsensusWorker::task(node_id, &client).await {
+            if let Err(e) = ConsensusWorker::task(node_id, metrics_address, &client).await {
                 error!("ConsensusWorker work error: {}", e)
             };
         });
@@ -31,7 +42,103 @@ impl ConsensusWorker {
         Ok(())
     }
 
-    async fn task(node_id: NodeID, client: &Client) -> Result<bool, ConsensusError> {
+    pub(crate) async fn execute_proposal(
+        proposal: Proposal,
+        leader: bool,
+        metrics_addr: Option<Addr<Metrics>>,
+        client: &Client,
+    ) -> Result<(), ConsensusError>
+    {
+        let view = if leader {
+            // Find pending view for asset, switch to commit
+            let asset_id = proposal.new_view.asset_id.clone();
+            let found_view = View::find_by_asset_status(&asset_id, ViewStatus::PreCommit, &client)
+                .await?
+                .first()
+                .map(|v| v.clone())
+                .ok_or_else(|| DBError::NotFound)?;
+
+            found_view
+                .update(
+                    UpdateView {
+                        status: Some(ViewStatus::Commit),
+                        proposal_id: Some(proposal.id),
+                        ..UpdateView::default()
+                    },
+                    &client,
+                )
+                .await?
+        } else {
+            View::insert(
+                proposal.new_view.clone(),
+                NewViewAdditionalParameters {
+                    status: Some(ViewStatus::Commit),
+                    proposal_id: Some(proposal.id),
+                },
+                &client,
+            )
+            .await?
+        };
+
+        for asset_state_append_only in &*view.append_only_state.asset_state {
+            AssetState::store_append_only_state(&asset_state_append_only, &client).await?;
+        }
+
+        for token_state_append_only in &*view.append_only_state.token_state {
+            Token::store_append_only_state(&token_state_append_only, &client).await?;
+        }
+
+        let proposal = proposal
+            .update(
+                UpdateProposal {
+                    status: Some(ProposalStatus::Finalized),
+                    ..UpdateProposal::default()
+                },
+                &client,
+            )
+            .await?;
+
+        let instruction_set: Vec<InstructionID> = view.instruction_set.iter().map(|i| InstructionID(*i)).collect();
+        let invalid_instruction_set: Vec<InstructionID> =
+            view.invalid_instruction_set.iter().map(|i| InstructionID(*i)).collect();
+
+        instruction_state::transition(
+            InstructionTransitionContext {
+                template_id: proposal.asset_id.template_id(),
+                instruction_ids: instruction_set,
+                proposal_id: Some(proposal.id),
+                current_status: InstructionStatus::Pending,
+                status: InstructionStatus::Commit,
+                result: None,
+                metrics_addr: metrics_addr.clone(),
+            },
+            &client,
+        )
+        .await?;
+
+        instruction_state::transition(
+            InstructionTransitionContext {
+                template_id: proposal.asset_id.template_id(),
+                instruction_ids: invalid_instruction_set,
+                proposal_id: Some(proposal.id),
+                current_status: InstructionStatus::Pending,
+                status: InstructionStatus::Invalid,
+                result: None,
+                metrics_addr: metrics_addr.clone(),
+            },
+            &client,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn task(
+        node_id: NodeID,
+        metrics_addr: Option<Addr<Metrics>>,
+        client: &Client,
+    ) -> Result<bool, ConsensusError>
+    {
         let committee = ConsensusCommittee::find_next_pending_committee(node_id, &client).await?;
         match committee {
             Some(committee) => {
@@ -77,7 +184,7 @@ impl ConsensusWorker {
 
                                 // Execute proposal for leader (other nodes will receive signed proposal and execute
                                 // upon validating supermajority signatures)
-                                proposal.execute(true, &client).await?;
+                                ConsensusWorker::execute_proposal(proposal, true, metrics_addr, &client).await?;
                             },
                             // Leader finalized proposal received, nodes confirm signatures, and apply state.
                             CommitteeState::LeaderFinalizedProposalReceived {
@@ -87,7 +194,7 @@ impl ConsensusWorker {
                                 aggregate_signature_message.validate(&client).await?;
 
                                 // Execute proposal for non leader nodes
-                                proposal.execute(false, &client).await?;
+                                ConsensusWorker::execute_proposal(proposal, false, metrics_addr, &client).await?;
                             },
                         }
 
@@ -112,25 +219,88 @@ mod test {
     use crate::{
         db::models::{
             consensus::{AggregateSignatureMessage, Instruction, Proposal, SignedProposal, View},
+            AssetStatus,
+            NewAssetStateAppendOnly,
+            NewTokenStateAppendOnly,
+            TokenStatus,
             *,
         },
         test::utils::{
-            builders::consensus::{
-                AggregateSignatureMessageBuilder,
-                InstructionBuilder,
-                ProposalBuilder,
-                SignedProposalBuilder,
-                ViewBuilder,
+            builders::{
+                consensus::{
+                    AggregateSignatureMessageBuilder,
+                    InstructionBuilder,
+                    ProposalBuilder,
+                    SignedProposalBuilder,
+                    ViewBuilder,
+                },
+                TokenBuilder,
             },
             test_db_client,
         },
+        types::consensus::AppendOnlyState,
     };
+    use serde_json::json;
+
+    #[actix_rt::test]
+    async fn execute_proposal() {
+        let (client, _lock) = test_db_client().await;
+        let mut proposal = ProposalBuilder::default().build(&client).await.unwrap();
+
+        let token = TokenBuilder::default().build(&client).await.unwrap();
+        let asset = AssetState::load(token.asset_state_id, &client).await.unwrap();
+        let instruction = InstructionBuilder {
+            asset_id: Some(asset.asset_id.clone()),
+            token_id: Some(token.token_id.clone()),
+            ..InstructionBuilder::default()
+        }
+        .build(&client)
+        .await
+        .unwrap();
+
+        proposal.new_view.instruction_set = vec![instruction.id.0];
+        proposal.new_view.append_only_state = AppendOnlyState {
+            asset_state: vec![NewAssetStateAppendOnly {
+                asset_id: asset.asset_id.clone(),
+                instruction_id: instruction.id,
+                status: AssetStatus::Active,
+                state_data_json: json!({"asset-value": true, "asset-value2": 1}),
+            }],
+            token_state: vec![NewTokenStateAppendOnly {
+                token_id: token.token_id,
+                instruction_id: instruction.id,
+                status: TokenStatus::Active,
+                state_data_json: json!({"token-value": true, "token-value2": 1}),
+            }],
+        };
+
+        // Execute as non leader triggering new view commit along with persistence of append only data
+        let proposal_id = proposal.id.clone();
+        ConsensusWorker::execute_proposal(proposal, false, None, &client)
+            .await
+            .unwrap();
+
+        let asset = AssetState::load(token.asset_state_id, &client).await.unwrap();
+        assert_eq!(
+            asset.additional_data_json,
+            json!({"asset-value": true, "asset-value2": 1})
+        );
+        let token = Token::load(token.id, &client).await.unwrap();
+        assert_eq!(
+            token.additional_data_json,
+            json!({"token-value": true, "token-value2": 1})
+        );
+        let proposal = Proposal::load(proposal_id, &client).await.unwrap();
+        assert_eq!(proposal.status, ProposalStatus::Finalized);
+        let view = View::load_for_proposal(proposal.id, &client).await.unwrap();
+        assert_eq!(view.status, ViewStatus::Commit);
+    }
 
     #[actix_rt::test]
     async fn task_preparing_view() {
         let (client, _lock) = test_db_client().await;
         let instruction = InstructionBuilder::default().build(&client).await.unwrap();
-        assert!(ConsensusWorker::task(NodeID::stub(), &client).await.unwrap());
+        assert!(ConsensusWorker::task(NodeID::stub(), None, &client).await.unwrap());
 
         let view_response = View::threshold_met(&client).await.unwrap();
         let (_, views) = view_response.iter().next().unwrap();
@@ -146,7 +316,7 @@ mod test {
     async fn task_view_threshold_reached() {
         let (client, _lock) = test_db_client().await;
         let view = ViewBuilder::default().build(&client).await.unwrap();
-        assert!(ConsensusWorker::task(NodeID::stub(), &client).await.unwrap());
+        assert!(ConsensusWorker::task(NodeID::stub(), None, &client).await.unwrap());
 
         // Leader signs proposal immediately so fetch proposal through signed proposal pending
         let signed_proposal_data = SignedProposal::threshold_met(&client).await.unwrap();
@@ -162,7 +332,7 @@ mod test {
     async fn task_received_leader_proposal() {
         let (client, _lock) = test_db_client().await;
         let proposal = ProposalBuilder::default().build(&client).await.unwrap();
-        assert!(ConsensusWorker::task(NodeID::stub(), &client).await.unwrap());
+        assert!(ConsensusWorker::task(NodeID::stub(), None, &client).await.unwrap());
 
         let signed_proposal_data = SignedProposal::threshold_met(&client).await.unwrap();
         let (_, signed_proposals) = signed_proposal_data.iter().next().unwrap();
@@ -200,7 +370,7 @@ mod test {
         .build(&client)
         .await
         .unwrap();
-        assert!(ConsensusWorker::task(NodeID::stub(), &client).await.unwrap());
+        assert!(ConsensusWorker::task(NodeID::stub(), None, &client).await.unwrap());
 
         let aggregate_signature_messages = AggregateSignatureMessage::load_by_proposal_id(proposal.id, &client)
             .await
@@ -243,7 +413,7 @@ mod test {
         .build(&client)
         .await
         .unwrap();
-        assert!(ConsensusWorker::task(NodeID::stub(), &client).await.unwrap());
+        assert!(ConsensusWorker::task(NodeID::stub(), None, &client).await.unwrap());
 
         let aggregate_signature_message = AggregateSignatureMessage::load(aggregate_signature_message.id, &client)
             .await

--- a/node/src/consensus/instruction_state.rs
+++ b/node/src/consensus/instruction_state.rs
@@ -1,0 +1,75 @@
+use super::errors::ConsensusError;
+use crate::{
+    db::models::{consensus::Instruction, InstructionStatus},
+    metrics::{
+        events::{InstructionEvent, MetricEvent},
+        metrics::Metrics,
+    },
+    types::*,
+};
+use actix::Addr;
+use deadpool_postgres::Client;
+use serde_json::Value;
+
+const LOG_TARGET: &'static str = "tari_validator_node::consensus";
+
+pub struct InstructionTransitionContext {
+    pub template_id: TemplateID,
+    pub instruction_ids: Vec<InstructionID>,
+    pub proposal_id: Option<ProposalID>,
+    pub current_status: InstructionStatus,
+    pub status: InstructionStatus,
+    pub result: Option<Value>,
+    pub metrics_addr: Option<Addr<Metrics>>,
+}
+
+impl InstructionTransitionContext {
+    /// Update [Metrics] Actor (if configured) with instruction update
+    fn metrics_update(&self) {
+        if let Some(metrics_addr) = self.metrics_addr.as_ref() {
+            for instruction_id in &self.instruction_ids {
+                let msg: MetricEvent = InstructionEvent {
+                    id: instruction_id.clone(),
+                    status: self.status,
+                }
+                .into();
+                metrics_addr.do_send(msg);
+            }
+        }
+    }
+}
+
+pub async fn transition(context: InstructionTransitionContext, client: &Client) -> Result<(), ConsensusError> {
+    log::trace!(
+        target: LOG_TARGET,
+        "template={}, instructions={:?}",
+        context.template_id,
+        context.instruction_ids
+    );
+
+    // Valid state transitions
+    match (context.current_status, context.status) {
+        (InstructionStatus::Scheduled, InstructionStatus::Processing) |
+        (InstructionStatus::Processing, InstructionStatus::Pending) |
+        (InstructionStatus::Processing, InstructionStatus::Invalid) |
+        (InstructionStatus::Pending, InstructionStatus::Invalid) |
+        (InstructionStatus::Pending, InstructionStatus::Commit) => {},
+        (a, b) => {
+            return Err(ConsensusError::error(&format!(
+                "Invalid Instruction {:?} status {} transition {:?}",
+                context.instruction_ids, a, b
+            )));
+        },
+    }
+
+    Instruction::update_instructions_status(
+        &context.instruction_ids,
+        context.proposal_id,
+        context.status,
+        context.result.to_owned(),
+        &client,
+    )
+    .await?;
+    context.metrics_update();
+    Ok(())
+}

--- a/node/src/consensus/mod.rs
+++ b/node/src/consensus/mod.rs
@@ -11,5 +11,6 @@ mod consensus_committee;
 mod consensus_processor;
 mod consensus_worker;
 pub mod errors;
+pub mod instruction_state;
 
 const LOG_TARGET: &'static str = "tari_validator_node::consensus";

--- a/node/src/template/errors.rs
+++ b/node/src/template/errors.rs
@@ -1,4 +1,4 @@
-use crate::{db::utils::errors::DBError, wallet::WalletError};
+use crate::{consensus::errors::ConsensusError, db::utils::errors::DBError, wallet::WalletError};
 use std::backtrace::Backtrace;
 use thiserror::Error;
 
@@ -35,6 +35,8 @@ pub enum TemplateError {
     },
     #[error("Internal Template error: {0}")]
     Internal(#[source] anyhow::Error),
+    #[error("Consensus error: {0}")]
+    ConsensusError(#[from] ConsensusError),
 }
 
 #[macro_export]


### PR DESCRIPTION
## Description
Refactored some of the instruction state logic so that it's more centralized and adjusted some additional logic to better encapsulate functionality. 

We discussed potentially modifying the instruction state machine logic to use the state_machine_futures crate or perhaps an actor approach of handling state changes as messages. After some investigation there were a few blockers: 1) that crate has to set an initial state and it transitions by polling for changes while our instructions need to be fetched from their db state as the initial state and external factors such as the consensus algorithm control state transitions so polling for updates seems wasteful if we had one of these for each instruction, 2) we need to be able to wrap this behavior in a db transaction to rollback in the event some other aspect of the proposal execution fails so we can't rely on an actor.

Opted to just use an enum mapping of acceptable transitions for now and encapsulated the transition logic in the instruction state module of the consensus logic.

## Motivation and Context
The instruction status change from pending -> invalid and pending -> commit were not handled.

## How Has This Been Tested?
```
cargo run instruction asset "0000000100000000000000000000000.00000000000000000000000000000F1E" issue_tokens '{"amount":10}'
Instruction -> Asset { asset_id: AssetID { template_id: TemplateID { template_type: 1, template_version: 0, tail: 0 }, features: 0, raid_id: RaidID("000000000000000"), hash: "00000000000000000000000000000F1E" }, contract_name: "issue_tokens", data: Object({"amount": Number(10)}) }


Instruction details
Root Id                                   Status     Params

 **  0a14c3a4-a510-11ea-8001-000102030405 Pending    {"IssueTokens":{"amount":10,"token_ids":null}}
```

<img width="1728" alt="Screen Shot 2020-06-02 at 4 31 40 PM" src="https://user-images.githubusercontent.com/1319304/83567832-3ebe8100-a4f0-11ea-8d4c-4b3a83e58e90.png">


```
cargo run instruction  status 0a14c3a4-a510-11ea-8001-000102030405
Instruction -> Status { instruction_id: InstructionID(0a14c3a4-a510-11ea-8001-000102030405) }


Instruction details
Root Id                                   Status     Params

 **  0a14c3a4-a510-11ea-8001-000102030405 Commit     {"IssueTokens":{"amount":10,"token_ids":null}}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [] New Tests
* [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [x] I'm merging against the `development` branch.
* [x] I ran `cargo-fmt --all` before pushing.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
