### PR TITLE
TemplateRunner hardening on handling load

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ awc = "1.0"
 anyhow = "1"
 config = { version = "0.9.3", default_features = false }
 dotenv = "0.15"
+deadpool = "0.5"
 deadpool-postgres = { version = "0.5.5", features = ["config"] }
 futures = "0.3"
 lazy_static = "1.4"

--- a/cli/src/commands/instructions.rs
+++ b/cli/src/commands/instructions.rs
@@ -5,14 +5,15 @@ use std::time::Duration;
 use structopt::StructOpt;
 use tari_validator_node::{
     config::NodeConfig,
-    db::{models::consensus::instructions::*, utils::db::db_client_raw},
+    db::models::consensus::instructions::*,
     template::{asset_call_path, token_call_path},
     types::{AssetID, InstructionID, TokenID},
 };
 use tokio::time::delay_for;
 use tokio_postgres::Client;
 
-const WAIT: Duration = Duration::from_secs(1);
+const WAIT: Duration = Duration::from_millis(1000);
+const MAX_RETRIES: usize = 60;
 
 #[derive(StructOpt, Debug)]
 pub enum InstructionCommands {
@@ -20,81 +21,146 @@ pub enum InstructionCommands {
         asset_id: AssetID,
         contract_name: String,
         data: Value,
+        /// Do not show progress, do not output result
+        #[structopt(long)]
+        silent: bool,
+        /// Wait for Commit (by default is waiting for Pending)
+        #[structopt(long)]
+        wait_commit: bool,
     },
     Token {
         token_id: TokenID,
         contract_name: String,
         data: Value,
+        /// Do not show progress, do not output result
+        #[structopt(long)]
+        silent: bool,
+        /// Wait for Commit (by default is waiting for Pending)
+        #[structopt(long)]
+        wait_commit: bool,
     },
     // Status of instruction and all subinstructions
     Status {
         instruction_id: InstructionID,
     },
+    // View details of instruction
     View {
         instruction_id: InstructionID,
     },
 }
 
 impl InstructionCommands {
-    pub async fn run(self, node_config: NodeConfig) -> anyhow::Result<Option<Instruction>> {
-        let client = db_client_raw(&node_config).await?;
+    pub async fn run(self, node_config: NodeConfig, client: &Client) -> anyhow::Result<Instruction> {
         match self {
             Self::Asset {
                 asset_id,
                 contract_name,
                 data,
+                silent,
+                wait_commit,
             } => {
-                let web = WebClient::default();
                 let url = asset_call_path(&asset_id, contract_name.as_str());
                 let url = format!("http://localhost:{}{}", node_config.actix.port, url);
-                let mut resp = web.post(url).send_json(&data).await.unwrap();
-                if resp.status().is_success() {
-                    let instruction: Instruction = resp.json().await.unwrap();
-                    delay_for(WAIT).await;
-                    display_instruction_status(instruction.id, &client).await?;
-                    return Ok(Some(instruction));
-                } else {
-                    println!("Request Failed: {:?}", resp.body().await);
-                }
+                Self::call(url, data, silent, wait_commit, client).await
             },
             Self::Token {
                 token_id,
                 contract_name,
                 data,
+                silent,
+                wait_commit,
             } => {
-                let web = WebClient::default();
                 let url = token_call_path(&token_id, contract_name.as_str());
                 let url = format!("http://localhost:{}{}", node_config.actix.port, url);
-                let mut resp = web.post(url).send_json(&data).await.unwrap();
-                if resp.status().is_success() {
-                    let instruction: Instruction = resp.json().await.unwrap();
-                    delay_for(WAIT).await;
-                    display_instruction_status(instruction.id, &client).await?;
-                    return Ok(Some(instruction));
-                } else {
-                    println!("Request Failed: {:?}", resp.body().await);
-                }
+                Self::call(url, data, silent, wait_commit, client).await
             },
             Self::Status { instruction_id } => {
-                display_instruction_status(instruction_id, &client).await?;
+                let instruction = Instruction::load(instruction_id, &client).await?;
+                Self::display_instruction_status(&instruction, client).await?;
+                Ok(instruction)
             },
             Self::View { instruction_id } => {
-                let instruction = Instruction::load(instruction_id, &client).await?;
+                let instruction = Instruction::load(instruction_id, client).await?;
                 Terminal::basic().render_object("Instruction details", instruction.clone());
-                return Ok(Some(instruction));
+                Ok(instruction)
             },
-        };
-        Ok(None)
+        }
     }
-}
 
-async fn display_instruction_status(instruction_id: InstructionID, client: &Client) -> anyhow::Result<()> {
-    let instruction = Instruction::load(instruction_id, &client).await?;
-    let subinstructions = instruction.load_subinstructions(&client).await?;
-    let mut instructions = vec![instruction_view(&instruction, true)];
-    instructions.extend(subinstructions.iter().map(|i| instruction_view(i, false)));
-    Terminal::basic().render_list("Instruction details", instructions, COLUMNS, SIZES);
-    Ok(())
+    pub async fn call(
+        url: String,
+        data: Value,
+        silent: bool,
+        wait_commit: bool,
+        client: &Client,
+    ) -> anyhow::Result<Instruction>
+    {
+        let web = WebClient::default();
+        let mut resp = web.post(&url).send_json(&data).await.unwrap();
+        if resp.status().is_success() {
+            let instruction: Instruction = match resp.json::<Value>().await {
+                Ok(val) => {
+                    if let Some(err) = val.as_object().expect("Expected object in response").get("error") {
+                        return Err(anyhow::anyhow!("POST {} failed: {}", url, err));
+                    } else {
+                        serde_json::from_value(val)?
+                    }
+                },
+                Err(err) => {
+                    return Err(anyhow::anyhow!("POST {} failed: {}", url, err));
+                },
+            };
+
+            if wait_commit {
+                Ok(Self::wait_status(&instruction, InstructionStatus::Commit, client, silent).await?)
+            } else {
+                Ok(Instruction::load(instruction.id, client).await?)
+            }
+        } else {
+            Err(anyhow::anyhow!("Request Failed: {:?}", resp.body().await))
+        }
+    }
+
+    pub async fn wait_status(
+        instruction: &Instruction,
+        status: InstructionStatus,
+        client: &Client,
+        silent: bool,
+    ) -> anyhow::Result<Instruction>
+    {
+        let mut retries = 0;
+        loop {
+            let instruction = Instruction::load(instruction.id, &client).await?;
+            if !silent {
+                Self::display_instruction_status(&instruction, &client).await?;
+            }
+            if instruction.status == status || instruction.status == InstructionStatus::Commit {
+                return Ok(instruction);
+            } else if instruction.status == InstructionStatus::Invalid {
+                return Err(anyhow::anyhow!(
+                    "Instruction {} Invalid {}",
+                    instruction.id,
+                    instruction.result
+                ));
+            }
+            delay_for(WAIT).await;
+            retries += 1;
+            if retries > MAX_RETRIES {
+                return Err(anyhow::anyhow!(
+                    "Timeout waiting for instruction {} Commit",
+                    instruction.id
+                ));
+            }
+        }
+    }
+
+    pub async fn display_instruction_status(instruction: &Instruction, client: &Client) -> anyhow::Result<()> {
+        let subinstructions = instruction.load_subinstructions(&client).await?;
+        let mut instructions = vec![instruction_view(instruction, true)];
+        instructions.extend(subinstructions.iter().map(|i| instruction_view(i, false)));
+        Terminal::basic().render_list("Instruction details", instructions, COLUMNS, SIZES);
+        Ok(())
+    }
 }
 
 const COLUMNS: &[&str] = &["Root", "Id", "Status", "Params", "Result"];

--- a/node/src/api/server.rs
+++ b/node/src/api/server.rs
@@ -30,7 +30,6 @@ pub async fn actix_main(
 ) -> anyhow::Result<()>
 {
     let pool = Arc::new(build_pool(&config.postgres)?);
-    let pool_actors = Arc::new(build_pool(&config.postgres)?);
 
     println!(
         "Server starting at {}",
@@ -45,7 +44,9 @@ pub async fn actix_main(
     });
 
     // TODO: so far predefined templates only... make templates runners configurable from main
-    let sut_runner = TemplateRunner::<SingleUseTokenTemplate>::create(pool_actors, config.clone(), metrics_addr);
+    // TODO: make distinct pool per template, though /status endpoint will need to provide status of all pools in that
+    // case
+    let sut_runner = TemplateRunner::<SingleUseTokenTemplate>::create(pool.clone(), config.clone(), metrics_addr);
     let sut_context = sut_runner.start();
 
     let cors_config = config.cors.clone();

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -2,7 +2,8 @@ use crate::{
     api::config::{ActixConfig, CorsConfig},
     consensus::ConsensusConfig,
 };
-use config::{Config, Environment, Source};
+use config::{Config, Environment, Source, Value};
+use deadpool::managed::PoolConfig;
 use deadpool_postgres::config::Config as DeadpoolConfig;
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 use tari_common::{ConfigurationError, DefaultConfigLoader, GlobalConfig, NetworkConfigPath};
@@ -39,54 +40,73 @@ impl NodeConfig {
         if env {
             let actix = Environment::with_prefix("ACTIX").collect()?;
             let pg = Environment::with_prefix("PG").collect()?;
-            let pg_pool = Environment::with_prefix("PG_POOL").collect()?;
-            let pg_pool_timeouts_recycle = Environment::with_prefix("PG_POOL_TIMEOUTS_RECYCLE").collect()?;
-            let pg_pool_timeouts_create = Environment::with_prefix("PG_POOL_TIMEOUTS_CREATE").collect()?;
-            let pg_pool_timeouts_wait = Environment::with_prefix("PG_POOL_TIMEOUTS_WAIT").collect()?;
             let cors = Environment::with_prefix("CORS").collect()?;
             let consensus = Environment::with_prefix("CONSENSUS").collect()?;
             config.set("validator.actix", actix).unwrap();
             config.set("validator.postgres", pg).unwrap();
-            if pg_pool.len() > 0 && pg_pool.contains_key("max_size") {
-                config.set("validator.postgres.pool", pg_pool).unwrap();
-            }
-            // TODO: this ideally should be fixed in deadpool config loader crate:
-            if pg_pool_timeouts_wait.len() > 0 {
-                if pg_pool_timeouts_wait.contains_key("secs") && pg_pool_timeouts_wait.contains_key("nanos") {
-                    config
-                        .set("validator.postgres.pool.timeouts.wait", pg_pool_timeouts_wait)
-                        .unwrap();
-                } else {
-                    panic!("PG_POOL_TIMEOUTS_WAIT should define _SECS and _NANOS suffixes")
-                }
-            }
-            if pg_pool_timeouts_create.len() > 0 {
-                if pg_pool_timeouts_create.contains_key("secs") && pg_pool_timeouts_create.contains_key("nanos") {
-                    config
-                        .set("validator.postgres.pool.timeouts.create", pg_pool_timeouts_create)
-                        .unwrap();
-                } else {
-                    panic!("PG_POOL_TIMEOUTS_CREATE should define _SECS and _NANOS suffixes")
-                }
-            }
-            if pg_pool_timeouts_recycle.len() > 0 {
-                if pg_pool_timeouts_recycle.contains_key("secs") && pg_pool_timeouts_recycle.contains_key("nanos") {
-                    config
-                        .set("validator.postgres.pool.timeouts.recycle", pg_pool_timeouts_recycle)
-                        .unwrap();
-                } else {
-                    panic!("PG_POOL_TIMEOUTS_RECYCLE should define _SECS and _NANOS suffixes")
-                }
-            }
             config.set("validator.cors", cors).unwrap();
             config.set("validator.consensus", consensus).unwrap();
+            if let Some(pg_pool) = Self::pg_pool_from_env()? {
+                config.set("validator.postgres.pool", pg_pool.collect()?).unwrap();
+            }
         }
-        if config.get_str("validator.public_address").is_err() {
-            config
-                .set("validator.public_address", global.public_address.to_string())
-                .unwrap();
-        }
+        Self::set_default(
+            &mut config,
+            "validator.public_address",
+            global.public_address.to_string(),
+        );
+        Self::set_default(&mut config, "validator.postgres.manager.recycling_method", "fast");
+        Self::set_default(
+            &mut config,
+            "validator.postgres.pool.max_size",
+            PoolConfig::default().max_size as i64,
+        );
         <Self as DefaultConfigLoader>::load_from(&config)
+    }
+
+    fn set_default<T: Into<Value>>(config: &mut Config, key: &str, value: T) {
+        if config.get_str(key).is_err() {
+            config.set(key, value).unwrap();
+        }
+    }
+
+    // Workaround of buggy deadpool_postgres config env loader
+    // TODO: this ideally should be fixed in deadpool config loader crate:
+    fn pg_pool_from_env() -> Result<Option<Config>, ConfigurationError> {
+        let pg_pool = Environment::with_prefix("PG_POOL").collect()?;
+        if pg_pool.len() == 0 {
+            return Ok(None);
+        }
+        let mut config = Config::new();
+        let pg_pool_timeouts_recycle = Environment::with_prefix("PG_POOL_TIMEOUTS_RECYCLE").collect()?;
+        let pg_pool_timeouts_create = Environment::with_prefix("PG_POOL_TIMEOUTS_CREATE").collect()?;
+        let pg_pool_timeouts_wait = Environment::with_prefix("PG_POOL_TIMEOUTS_WAIT").collect()?;
+        if pg_pool.len() > 0 && pg_pool.contains_key("max_size") {
+            let max_size = pg_pool.get("max_size").unwrap().clone().into_int()?;
+            config.set("max_size", max_size).unwrap();
+        }
+        if pg_pool_timeouts_wait.len() > 0 {
+            if pg_pool_timeouts_wait.contains_key("secs") && pg_pool_timeouts_wait.contains_key("nanos") {
+                config.set("timeouts.wait", pg_pool_timeouts_wait).unwrap();
+            } else {
+                panic!("PG_POOL_TIMEOUTS_WAIT should define _SECS and _NANOS suffixes")
+            }
+        }
+        if pg_pool_timeouts_create.len() > 0 {
+            if pg_pool_timeouts_create.contains_key("secs") && pg_pool_timeouts_create.contains_key("nanos") {
+                config.set("timeouts.create", pg_pool_timeouts_create).unwrap();
+            } else {
+                panic!("PG_POOL_TIMEOUTS_CREATE should define _SECS and _NANOS suffixes")
+            }
+        }
+        if pg_pool_timeouts_recycle.len() > 0 {
+            if pg_pool_timeouts_recycle.contains_key("secs") && pg_pool_timeouts_recycle.contains_key("nanos") {
+                config.set("timeouts.recycle", pg_pool_timeouts_recycle).unwrap();
+            } else {
+                panic!("PG_POOL_TIMEOUTS_RECYCLE should define _SECS and _NANOS suffixes")
+            }
+        }
+        Ok(Some(config))
     }
 }
 
@@ -105,40 +125,46 @@ mod test {
         test::utils::build_test_global_config,
     };
     use config::{Config, File, FileFormat::Toml};
+    use deadpool_postgres::config::*;
+    use std::time::Duration;
 
     lazy_static::lazy_static! {
     static ref LOCK_ENV: std::sync::RwLock<u8> = std::sync::RwLock::new(0);
     }
 
     #[test]
-    fn default_config() -> Result<(), ConfigurationError> {
-        let _guard = LOCK_ENV.read().unwrap();
+    fn default_config() {
         let global = build_test_global_config().unwrap();
-        let cfg = NodeConfig::load_from(&Config::new(), &global, false)?;
+        let cfg = NodeConfig::load_from(&Config::new(), &global, false).unwrap();
         assert_eq!(cfg.actix.port, DEFAULT_PORT);
         assert_eq!(cfg.actix.host, DEFAULT_ADDR);
         assert_eq!(cfg.postgres.host, None);
         assert_eq!(cfg.postgres.dbname, Some(DEFAULT_DBNAME.into()));
         assert_eq!(cfg.cors.allowed_origins, "*");
-        Ok(())
+        assert_eq!(
+            cfg.postgres.manager.map(|m| m.recycling_method),
+            Some(RecyclingMethod::Fast)
+        );
     }
 
     const TEST_CONFIG: &'static str = r#"
+    [validator.postgres]
+    host = "localhost"
+    user = "postgres"
+    pool = { timeouts = { wait = {secs = 5, nanos = 0} } }
     [validator]
     actix = { workers = 3, port = 9999 }
-    postgres = { host = "localhost", user = "postgres" }
     cors = { allowed_origins = "https://www.tari.com"}
     consensus = { workers = 10 }
     "#;
 
     #[test]
-    fn load_config() -> Result<(), ConfigurationError> {
-        let _guard = LOCK_ENV.read().unwrap();
+    fn load_config() {
         let global = build_test_global_config().unwrap();
         let mut settings = Config::new();
-        settings.merge(File::from_str(TEST_CONFIG, Toml))?;
+        settings.merge(File::from_str(TEST_CONFIG, Toml)).unwrap();
 
-        let cfg = NodeConfig::load_from(&settings, &global, false)?;
+        let cfg = NodeConfig::load_from(&settings, &global, false).unwrap();
         assert_eq!(cfg.actix.port, 9999);
         assert_eq!(cfg.actix.host, DEFAULT_ADDR);
         assert_eq!(cfg.actix.workers, Some(3));
@@ -146,29 +172,34 @@ mod test {
         assert_eq!(cfg.postgres.dbname, Some(DEFAULT_DBNAME.into()));
         assert_eq!(cfg.postgres.user, Some("postgres".into()));
         assert_eq!(cfg.postgres.password, None);
+        assert_eq!(
+            cfg.postgres.pool.map(|p| p.timeouts.wait).flatten(),
+            Some(Duration::from_secs(5))
+        );
         assert_eq!(cfg.cors.allowed_origins, "https://www.tari.com".to_string());
         assert_eq!(cfg.consensus.workers, Some(10));
-        Ok(())
     }
 
     const TEST_CONFIG_NETWORK: &'static str = r#"
     use_network = "rincewind"
     [validator.rincewind]
     actix = { host = "10.0.0.1" }
-    postgres = { host = "postgres", dbname = "validator_rincewind" }
+    [validator.rincewind.postgres]
+    host = "postgres"
+    dbname = "validator_rincewind"
+    pool = { max_size = 5 }
     "#;
 
     #[test]
-    fn network_overload_config() -> Result<(), ConfigurationError> {
+    fn network_overload_config() {
         use std::net::IpAddr;
 
-        let _guard = LOCK_ENV.read().unwrap();
         let global = build_test_global_config().unwrap();
         let mut settings = Config::new();
         let cfg_with_network = format!("{}{}", TEST_CONFIG, TEST_CONFIG_NETWORK);
-        settings.merge(File::from_str(cfg_with_network.as_str(), Toml))?;
+        settings.merge(File::from_str(cfg_with_network.as_str(), Toml)).unwrap();
 
-        let cfg = NodeConfig::load_from(&settings, &global, false)?;
+        let cfg = NodeConfig::load_from(&settings, &global, false).unwrap();
         assert_eq!(cfg.actix.port, 9999);
         assert_eq!(cfg.actix.host, "10.0.0.1".parse::<IpAddr>().unwrap());
         assert_eq!(cfg.actix.workers, Some(3));
@@ -176,16 +207,20 @@ mod test {
         assert_eq!(cfg.postgres.dbname, Some("validator_rincewind".into()));
         assert_eq!(cfg.postgres.user, Some("postgres".into()));
         assert_eq!(cfg.postgres.password, None);
-        Ok(())
+        assert_eq!(cfg.postgres.pool.clone().map(|p| p.max_size), Some(5));
+        assert_eq!(
+            cfg.postgres.pool.map(|p| p.timeouts.wait).flatten(),
+            Some(Duration::from_secs(5))
+        );
     }
 
     #[test]
-    fn env_overload_config() -> Result<(), ConfigurationError> {
+    fn env_overload_config() {
         // make sure that env settings do not interfere with other tests
         let _guard = LOCK_ENV.write().unwrap();
         let global = build_test_global_config().unwrap();
         let mut settings = Config::new();
-        settings.merge(File::from_str(TEST_CONFIG, Toml))?;
+        settings.merge(File::from_str(TEST_CONFIG, Toml)).unwrap();
         std::env::remove_var("PG_USER");
         std::env::remove_var("PG_DBNAME");
         std::env::set_var("PG_HOST", "postgres");
@@ -193,7 +228,7 @@ mod test {
         std::env::set_var("ACTIX_WORKERS", "5");
         std::env::set_var("ACTIX_PORT", "5000");
 
-        let cfg = NodeConfig::load_from(&settings, &global, true)?;
+        let cfg = NodeConfig::load_from(&settings, &global, true).unwrap();
         assert_eq!(cfg.actix.port, 5000);
         assert_eq!(cfg.actix.host, DEFAULT_ADDR);
         assert_eq!(cfg.actix.workers, Some(5));
@@ -206,7 +241,54 @@ mod test {
         std::env::remove_var("PG_HOST");
         std::env::remove_var("ACTIX_WORKERS");
         std::env::remove_var("ACTIX_PORT");
+    }
 
-        Ok(())
+    #[test]
+    fn pool_env_overload_config() {
+        // make sure that env settings do not interfere with other tests
+        let _guard = LOCK_ENV.write().unwrap();
+        let global = build_test_global_config().unwrap();
+        let mut settings = Config::new();
+        settings.merge(File::from_str(TEST_CONFIG, Toml)).unwrap();
+        std::env::remove_var("PG_POOL_MAX_SIZE");
+        std::env::remove_var("PG_POOL_TIMEOUTS_WAIT_SECS");
+        std::env::remove_var("PG_POOL_TIMEOUTS_WAIT_NANOS");
+        std::env::remove_var("PG_POOL_TIMEOUTS_RECYCLE_SECS");
+        std::env::remove_var("PG_POOL_TIMEOUTS_RECYCLE_NANOS");
+        std::env::remove_var("PG_POOL_TIMEOUTS_CREATE_SECS");
+        std::env::remove_var("PG_POOL_TIMEOUTS_CREATE_NANOS");
+
+        std::env::set_var("PG_POOL_MAX_SIZE", "3");
+        let cfg = NodeConfig::load_from(&settings, &global, true).unwrap();
+        let pool = cfg.postgres.pool.unwrap();
+        assert_eq!(pool.max_size, 3);
+
+        std::env::set_var("PG_POOL_TIMEOUTS_WAIT_SECS", "1");
+        std::env::set_var("PG_POOL_TIMEOUTS_WAIT_NANOS", "0");
+        let cfg = NodeConfig::load_from(&settings, &global, true).unwrap();
+        let pool = cfg.postgres.pool.unwrap();
+        assert_eq!(pool.timeouts.wait, Some(Duration::from_secs(1)));
+        assert_eq!(pool.timeouts.recycle, None);
+        assert_eq!(pool.timeouts.create, None);
+
+        std::env::set_var("PG_POOL_TIMEOUTS_RECYCLE_SECS", "2");
+        std::env::set_var("PG_POOL_TIMEOUTS_RECYCLE_NANOS", "0");
+        let cfg = NodeConfig::load_from(&settings, &global, true).unwrap();
+        let pool = cfg.postgres.pool.unwrap();
+        assert_eq!(pool.timeouts.recycle, Some(Duration::from_secs(2)));
+
+        std::env::set_var("PG_POOL_TIMEOUTS_CREATE_SECS", "3");
+        std::env::set_var("PG_POOL_TIMEOUTS_CREATE_NANOS", "0");
+        let cfg = NodeConfig::load_from(&settings, &global, true).unwrap();
+        let pool = cfg.postgres.pool.unwrap();
+        assert_eq!(pool.timeouts.create, Some(Duration::from_secs(3)));
+
+        std::env::remove_var("PG_POOL_MAX_SIZE");
+        std::env::remove_var("PG_POOL_TIMEOUTS_WAIT_SECS");
+        std::env::remove_var("PG_POOL_TIMEOUTS_WAIT_NANOS");
+        std::env::remove_var("PG_POOL_TIMEOUTS_RECYCLE_SECS");
+        std::env::remove_var("PG_POOL_TIMEOUTS_RECYCLE_NANOS");
+        std::env::remove_var("PG_POOL_TIMEOUTS_CREATE_SECS");
+        std::env::remove_var("PG_POOL_TIMEOUTS_CREATE_NANOS");
     }
 }

--- a/node/src/template/errors.rs
+++ b/node/src/template/errors.rs
@@ -4,13 +4,13 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum TemplateError {
-    #[error("DB error in Template: {source} {backtrace}")]
+    #[error("DB error in Template: {source}")]
     DB {
         #[from]
         source: DBError,
         backtrace: Backtrace,
     },
-    #[error("Wallet error in Template: {source} {backtrace}")]
+    #[error("Wallet error in Template: {source}")]
     Wallet {
         #[from]
         source: WalletError,
@@ -27,7 +27,7 @@ pub enum TemplateError {
         #[source]
         source: anyhow::Error,
     },
-    #[error("Failed to receive actor response: {source} {backtrace}")]
+    #[error("Failed to receive actor response: {source}")]
     ActorResponse {
         #[from]
         source: actix::MailboxError,

--- a/node/src/template/single_use_tokens.rs
+++ b/node/src/template/single_use_tokens.rs
@@ -173,7 +173,7 @@ impl TokenContracts {
         while context.check_balance(&wallet_key).await? < price {
             tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
             if timeout.elapsed() > timeout_secs {
-                // TODO: any failure in instrustion should also fail all subinstructions in transaction
+                // TODO: any failure in instruction should also fail all subinstructions in transaction
                 let data = UpdateToken {
                     status: Some(TokenStatus::Active),
                     ..Default::default()

--- a/node/src/template/single_use_tokens.rs
+++ b/node/src/template/single_use_tokens.rs
@@ -50,7 +50,7 @@ impl AssetContracts {
     pub async fn issue_tokens(
         context: &mut AssetInstructionContext<SingleUseTokenTemplate>,
         IssueTokensParams { token_ids, quantity }: IssueTokensParams,
-    ) -> Result<Vec<Token>, TemplateError>
+    ) -> Result<Vec<TokenID>, TemplateError>
     {
         let token_ids: Vec<TokenID> = if let Some(token_ids) = token_ids {
             token_ids
@@ -64,26 +64,24 @@ impl AssetContracts {
                 return validation_err!("Either token_ids or quantity should be specified in request json body");
             }
         };
-        let mut tokens = Vec::with_capacity(token_ids.len());
         let asset = &context.asset;
         let data = TokenData {
             owner_pubkey: asset.asset_issuer_pub_key.clone(),
             used: false,
         };
-        let new_token = move |token_id| NewToken {
-            token_id,
+        let new_token = move |token_id: &TokenID| NewToken {
+            token_id: token_id.clone(),
             asset_state_id: asset.id.clone(),
             initial_data_json: json!(data),
             ..NewToken::default()
         };
-        for data in token_ids.into_iter().map(new_token) {
+        for data in token_ids.iter().map(new_token) {
             if data.token_id.asset_id() != asset.asset_id {
                 return validation_err!("Token ID {} does not match asset {}", data.token_id, asset.asset_id);
             }
-            let token = context.create_token(data).await?;
-            tokens.push(token);
+            context.create_token(data).await?;
         }
-        Ok(tokens)
+        Ok(token_ids)
     }
 }
 
@@ -175,7 +173,12 @@ impl TokenContracts {
         while context.check_balance(&wallet_key).await? < price {
             tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
             if timeout.elapsed() > timeout_secs {
-                // TODO: any failure in instrustion should also fail all subinstructions
+                // TODO: any failure in instrustion should also fail all subinstructions in transaction
+                let data = UpdateToken {
+                    status: Some(TokenStatus::Active),
+                    ..Default::default()
+                };
+                let _ = context.update_token(data).await;
                 return validation_err!("Timeout expired for sell_token");
             }
         }
@@ -436,9 +439,9 @@ mod test {
         .into();
 
         let (tokens, _) = contract.call(context).await.unwrap();
-        let tokens: Vec<Token> = serde_json::from_value(tokens).unwrap();
-        for (token, token_id) in tokens.iter().zip(token_ids.iter()) {
-            assert_eq!(token.token_id, *token_id);
+        let result: Vec<TokenID> = serde_json::from_value(tokens).unwrap();
+        for (token_id1, token_id2) in result.iter().zip(token_ids.iter()) {
+            assert_eq!(token_id1, token_id2);
         }
 
         let context = build_context().await;
@@ -449,9 +452,9 @@ mod test {
         }
         .into();
         let (tokens, _) = contract.call(context).await.unwrap();
-        let tokens: Vec<Token> = serde_json::from_value(tokens).unwrap();
-        for token in tokens.iter() {
-            assert_eq!(token.token_id.asset_id(), asset_id);
+        let token_ids: Vec<TokenID> = serde_json::from_value(tokens).unwrap();
+        for token_id in token_ids.iter() {
+            assert_eq!(token_id.asset_id(), asset_id);
         }
     }
 
@@ -650,7 +653,8 @@ mod test {
         for _ in 0u8..10 {
             tokio::time::delay_for(std::time::Duration::from_millis(100)).await;
             let instruction = Instruction::load(id, &client).await.unwrap();
-            if instruction.status != InstructionStatus::Scheduled {
+            if instruction.status != InstructionStatus::Scheduled && instruction.status != InstructionStatus::Processing
+            {
                 assert_eq!(instruction.status, InstructionStatus::Invalid);
                 return;
             }

--- a/node/src/test/utils/builders/node_wallet_builder.rs
+++ b/node/src/test/utils/builders/node_wallet_builder.rs
@@ -16,6 +16,7 @@ impl Default for NodeWalletBuilder {
 }
 
 impl NodeWalletBuilder {
+    #[allow(dead_code)]
     pub fn build(self) -> anyhow::Result<NodeWallet> {
         Ok(NodeWallet::new(self.address, self.name)?)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Optimize make-it-rain on db usage and reporting
- Change issue_tokens result payload to Vec<TokenID>
- Error reporting and logging improvements
- Fix TemplateRunner pool draining, and few more concurrency issues
- Fix sell_token failure handling
- Fix pool config loading issues

## Motivation and Context
Issue_tokens was putting all created serialized tokens in instruction result as huge json
make-it-rain was using DB connections from the pool as well as distinct connections to DB, now it's limited to pool
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually as a CLI tool
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Feature refactor (No new feature or functional changes, but performance or technical debt improvements)
* [x] New Tests
* [X] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
* [X] I'm merging against the `development` branch.
* [X] I ran `cargo-fmt --all` before pushing.
* [x] My change requires a change to the documentation.
* [X] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
